### PR TITLE
Fix a typo in InboundChannelAdapter

### DIFF
--- a/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
+++ b/spring-integration-core/src/main/java/org/springframework/integration/annotation/InboundChannelAdapter.java
@@ -37,7 +37,7 @@ import org.springframework.core.annotation.AliasFor;
  * The result {@link org.springframework.messaging.Message} will be sent to the provided {@link #value()}.
  * <p>
  * {@code @InboundChannelAdapter} is an analogue of {@code <int:inbound-channel-adapter/>}. With that
- * the {@link org.springframework.integration.scheduling.PollerMetadata} is required to to initiate
+ * the {@link org.springframework.integration.scheduling.PollerMetadata} is required to initiate
  * the method invocation. Or {@link #poller()} should be provided, or the
  * {@link org.springframework.integration.scheduling.PollerMetadata#DEFAULT_POLLER} bean has to be configured
  * in the application context.


### PR DESCRIPTION
 `is required to to initiate` must be fixed to `is required to initiate`
 
 >  the {@link org.springframework.integration.scheduling.PollerMetadata} is required to to initiate the method invocation. Or {@link #poller()} should be provided

